### PR TITLE
Fix bug when `PATH` contains spaces

### DIFF
--- a/conf.d/nix.fish
+++ b/conf.d/nix.fish
@@ -1,3 +1,3 @@
 if test -e "$HOME/.nix-profile/etc/profile.d/nix.sh"
-  eval (bash -c "source $HOME/.nix-profile/etc/profile.d/nix.sh; echo export NIX_PATH=\"\$NIX_PATH\"; echo export PATH=\"\$PATH\"")
+  eval (bash -c "source $HOME/.nix-profile/etc/profile.d/nix.sh; echo export NIX_PATH=\\\"\$NIX_PATH\\\"; echo export PATH=\\\"\$PATH\\\"")
 end


### PR DESCRIPTION
The original version was broken when `PATH` contains spaces. This version should work